### PR TITLE
Feat/profile image initials fixes

### DIFF
--- a/src/lib/components/chat/Settings/Account.svelte
+++ b/src/lib/components/chat/Settings/Account.svelte
@@ -152,7 +152,7 @@
 							profileImageUrl = generateInitialsImage(name);
 						} else {
 							toast.error(
-								'Canvas pixel test failed, fingerprint evasion likely. Disable fingerprint evasion and try again!',
+								$i18n.t('Canvas pixel test failed, fingerprint evasion likely. Disable fingerprint evasion and try again!'),
 								{
 									autoClose: 1000 * 10
 								}

--- a/src/lib/components/chat/Settings/Account.svelte
+++ b/src/lib/components/chat/Settings/Account.svelte
@@ -152,7 +152,7 @@
 							profileImageUrl = generateInitialsImage(name);
 						} else {
 							toast.error(
-								$i18n.t('Canvas pixel test failed, fingerprint evasion likely. Disable fingerprint evasion and try again!'),
+								$i18n.t('Canvas pixel test failed: fingerprint evasion likely. Disable fingerprint evasion and try again!'),
 								{
 									autoClose: 1000 * 10
 								}

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -44,9 +44,13 @@
 		);
 
 		if (!canvasPixelTest()) {
-			toast.error('Canvas pixel test failed, fingerprint evasion likely. Default image used.', {
-				autoClose: 1000 * 10
-			});
+			toast.error(
+				$i18n.t('Canvas pixel test failed, fingerprint evasion likely. Default image used.'),
+				{
+					position: "bottom-center",
+					autoClose: 1000 * 10,
+				}
+			);
 		}
 
 		await setSessionUser(sessionUser);

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -45,7 +45,7 @@
 
 		if (!canvasPixelTest()) {
 			toast.error(
-				$i18n.t('Canvas pixel test failed, fingerprint evasion likely. Default image used.'),
+				$i18n.t('Canvas pixel test failed: fingerprint evasion likely. Using default avatar image.'),
 				{
 					position: "bottom-center",
 					autoClose: 1000 * 10,

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -43,6 +43,12 @@
 			}
 		);
 
+		if (!canvasPixelTest()) {
+			toast.error('Canvas pixel test failed, fingerprint evasion likely. Default image used.', {
+				autoClose: 1000 * 10
+			});
+		}
+
 		await setSessionUser(sessionUser);
 	};
 


### PR DESCRIPTION
Revert auth toast omission and move login page toast error to the bottom of page. Also enable i18n for translation.